### PR TITLE
Add caching to sitemap

### DIFF
--- a/app/controllers/cms/pages_controller.rb
+++ b/app/controllers/cms/pages_controller.rb
@@ -7,9 +7,12 @@ class PagesController < Cms::BaseController
   before_filter :load_draft_page, :only => [:edit, :update]
   before_filter :hide_toolbar, :only => [:new, :create]
   before_filter :strip_publish_params, :only => [:create, :update]
-
+  
+  cache_sweeper Cms::SitemapSweeper
+  
   helper Cms::RenderingHelper
   
+
   def new
     @page = Page.new(:section => @section, :cacheable => true)
     if @section.child_nodes.count < 1
@@ -36,6 +39,7 @@ class PagesController < Cms::BaseController
   def update
     if @page.update_attributes(params[:page])
       flash[:notice] = "Page was '#{@page.name}' updated."
+      Cms::SitemapSweeper.instance.after_update( @page )
       redirect_to @page
     else
       render :action => "edit"

--- a/app/controllers/cms/sections_controller.rb
+++ b/app/controllers/cms/sections_controller.rb
@@ -8,6 +8,8 @@ module Cms
     helper_method :public_groups
     helper_method :cms_groups
 
+    cache_sweeper Cms::SitemapSweeper
+
     def index
       redirect_to cms.sitemap_path
     end

--- a/app/sweepers/cms/sitemap_sweeper.rb
+++ b/app/sweepers/cms/sitemap_sweeper.rb
@@ -1,0 +1,41 @@
+module Cms
+  class SitemapSweeper < ActionController::Caching::Sweeper
+    observe Cms::Section
+    observe Cms::Page
+    
+    # If our sweeper detects that a Product was created call this
+    def after_create( node )
+      expire_cache_for( node.path )
+    end
+   
+    # If our sweeper detects that a Product was updated call this
+    def after_update( node )
+      expire_cache_for( node.path )
+    end
+    
+    # If our sweeper detects that a Product was deleted call this
+    def after_destroy( node )
+      expire_cache_for( node.path )
+    end
+   
+    private
+    def expire_cache_for( path )
+      # Expire a fragment
+      path_bits = path.split( '/' )
+      path_bits.shift
+
+      # the first / in the path is special, denoting the root
+      # so we have to expire it manually
+      expire_fragment( "cache_fragment_sitemap_/" )
+
+      # loop through the array of path segments,
+      # accumulating a running path 
+      # and clear the cache for it
+      path_bits.inject( '' ) { |path_accm, path_bit|
+        path_accm += "/#{path_bit}"
+        expire_fragment( "cache_fragment_sitemap_#{path_accm}" )
+        path_accm
+      }
+    end
+  end
+end

--- a/app/sweepers/cms/sitemap_sweeper.rb
+++ b/app/sweepers/cms/sitemap_sweeper.rb
@@ -20,20 +20,30 @@ module Cms
    
     private
     def expire_cache_for( path )
+      # get the list of user names that has been used in the cache
+      # sitemap cache is per user, so it needs to be deleted for each user
+      cache_users = Rails.cache.read( "cache_fragment_sitemap_users" ) || Set.new
+      
       # Expire a fragment
       path_bits = path.split( '/' )
       path_bits.shift
 
       # the first / in the path is special, denoting the root
       # so we have to expire it manually
-      expire_fragment( "cache_fragment_sitemap_/" )
+      cache_users.each do |user|
+        expire_fragment( "cache_fragment_sitemap_#{user}_/" )
+      end
 
       # loop through the array of path segments,
       # accumulating a running path 
       # and clear the cache for it
       path_bits.inject( '' ) { |path_accm, path_bit|
         path_accm += "/#{path_bit}"
-        expire_fragment( "cache_fragment_sitemap_#{path_accm}" )
+        
+        cache_users.each do |user|
+          expire_fragment( "cache_fragment_sitemap_#{user}_#{path_accm}" )
+        end
+
         path_accm
       }
     end

--- a/app/sweepers/cms/sitemap_sweeper.rb
+++ b/app/sweepers/cms/sitemap_sweeper.rb
@@ -49,3 +49,5 @@ module Cms
     end
   end
 end
+
+# nop comment

--- a/app/views/cms/section_nodes/_section.html.erb
+++ b/app/views/cms/section_nodes/_section.html.erb
@@ -14,15 +14,17 @@
             :access_icon => status_icon(access_status),
             :parent => parent
     } %>
-    <% children.each do |child_section_node| %>
-        <%= render :partial => child_section_node.node.partial_for,
-                   :locals => {:access_icon => access_status,
-                               :node => child_section_node.node,
-                               :parent => node,
-                               :child_hash => child_hash[key],
-                               :key => child_section_node
-                   } %>
+    <% cache( "cache_fragment_sitemap_#{node.path}" ) do %>
+      <% children.each do |child_section_node| %>
+            <%= render :partial => child_section_node.node.partial_for,
+                     :locals => {:access_icon => access_status,
+                                 :node => child_section_node.node,
+                                 :parent => node,
+                                 :child_hash => child_hash[key],
+                                 :key => child_section_node
+                     } %>
+        
+      <% end %>
     <% end %>
-
   </li>
 </ul>

--- a/app/views/cms/section_nodes/_section.html.erb
+++ b/app/views/cms/section_nodes/_section.html.erb
@@ -14,7 +14,15 @@
             :access_icon => status_icon(access_status),
             :parent => parent
     } %>
-    <% cache( "cache_fragment_sitemap_#{node.path}" ) do %>
+    
+    <%
+      # keep an ever growing list of users who have cache entries
+      cache_users = Rails.cache.read( "cache_fragment_sitemap_users" ) || Set.new
+      cache_users.add( current_user.id )
+      Rails.cache.write( "cache_fragment_sitemap_users", cache_users )
+    %>
+
+    <% cache( "cache_fragment_sitemap_#{current_user.id}_#{node.path}" ) do %>
       <% children.each do |child_section_node| %>
             <%= render :partial => child_section_node.node.partial_for,
                      :locals => {:access_icon => access_status,

--- a/lib/cms/engine.rb
+++ b/lib/cms/engine.rb
@@ -80,6 +80,7 @@ module Cms
       ActiveSupport::Dependencies.autoload_paths += %W( #{self.root}/app/controllers #{self.root}/app/models #{self.root}/app/portlets)
       ActiveSupport::Dependencies.autoload_paths += %W( #{Rails.root}/app/portlets )
       ActiveSupport::Dependencies.autoload_paths += %W( #{Rails.root}/app/portlets/helpers )
+      ActiveSupport::Dependencies.autoload_paths += %W( #{Rails.root}/app/sweepers )
       ActionController::Base.append_view_path DynamicView.base_path
       ActionController::Base.append_view_path %W( #{self.root}/app/views)
       ActionView::Base.default_form_builder = Cms::FormBuilder


### PR DESCRIPTION
These changes add a fragment cache around the sitemap subtree rendering point. A sitemap sweeper is also added which invalidates the fragments when changes are made to the tree.

Large trees may take multiple requests to fully render. Each request will cache more of the tree, until enough has been cached to complete the rendering in time. A pathological tree which is very flat may have nodes which can never be rendered in time, and so will never render.

Edits only invalidate the fragments along the path of the node.

Performance was improved significantly in testing.
An 11,000 node tree took 500 seconds for first render, with subsequent rendering from cache taking 5 seconds.
Using memcached as the backing store for the fragments had no significant impact.
