### PR TITLE
Feature/remove cms 404 500 handling

### DIFF
--- a/lib/cms/content_rendering_support.rb
+++ b/lib/cms/content_rendering_support.rb
@@ -48,30 +48,7 @@ module Cms
 
       # We must be showing the page outside of the CMS
       # So we will show the error page
-      if @page = Cms::Page.find_live_by_path(error_page_path)
-        logger.debug "Rendering Error Page: #{@page.inspect}"
-        @mode = "view"
-        @show_page_toolbar = false
-
-        # copy new instance variables to the template
-        %w[page mode show_page_toolbar].each do |v|
-          @template.instance_variable_set("@#{v}", instance_variable_get("@#{v}"))
-        end
-
-        # clear out any content already captured
-        # by previous attempts to render the page within this request
-        @template.instance_variables.select{|v| v =~ /@content_for_/ }.each do |v|
-          @template.instance_variable_set("#{v}", nil)
-        end
-
-        prepare_connectables_for_render
-
-        # The error pages are ALWAYS html since they are managed by the CMS as normal pages.
-        # So .gif or .jpg requests that throw errors will return html rather than a format warning.
-        render :layout => determine_page_layout, :template => 'cms/content/show', :status => status, :formats=>[:html]
-      else
-        handle_server_error(exception)
-      end
+      return render status: 500
     end
 
     # If any of the page's connectables (portlets, etc) are renderable, they may have a render method

--- a/lib/cms/content_rendering_support.rb
+++ b/lib/cms/content_rendering_support.rb
@@ -44,7 +44,11 @@ module Cms
 
       # We must be showing the page outside of the CMS
       # So we will show the error page
-      render :file => "#{Rails.root}/public/404", :layout => false, :status => status
+      if status == :not_found
+        render :file => "#{Rails.root}/public/404", :layout => false, :status => status
+      else
+        render :file => "#{Rails.root}/public/500", :layout => false, :status => status
+      end
     end
 
 

--- a/lib/cms/content_rendering_support.rb
+++ b/lib/cms/content_rendering_support.rb
@@ -40,16 +40,13 @@ module Cms
     def handle_error_with_cms_page(error_page_path, exception, status, options={})
 
       # If we are in the CMS, we just want to show the exception
-      if perform_caching
-        return handle_server_error(exception) if cms_site?
-      else
         return handle_server_error(exception) if current_user.able_to?(:edit_content, :publish_content)
-      end
 
       # We must be showing the page outside of the CMS
       # So we will show the error page
-      return render status: 500
+      render :file => "#{Rails.root}/public/404", :layout => false, :status => status
     end
+
 
     # If any of the page's connectables (portlets, etc) are renderable, they may have a render method
     # which does "controller" stuff, so we need to get that run before rendering the page.


### PR DESCRIPTION
Currently BrowserCMS handles the creation, rendering, and serving of HTTP 404 and HTTP 500 error pages within the application itself. This is undesirable behaviour.

This PR bypasses most of the BCMS error handling and instead renders the 404/500 files in the public folder. If the user is an admin and logged in, it will continue to catch and display the error in regular fashion.

I've tested this locally and on a QA site, but would consider it an experimental feature.
